### PR TITLE
Readme fixes: highlighting, update apt repository setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In addition to the plugin code, this repository contains additional files for th
 
 ## Installation of the D3C Plugin
 
-As the D3C plugin is a standard Netbox plugin, it can be installed according to the [Netbox documentation](https://docs.netbox.dev/en/stable/plugins/#installing-plugins). This plugin is compatible with Netbox version 3.6.x and ensured by plugins `setup.py` file.  
+As the D3C plugin is a standard Netbox plugin, it can be installed according to the [Netbox documentation](https://docs.netbox.dev/en/stable/plugins/#installing-plugins). This plugin is compatible with Netbox version 3.6.x and ensured by plugins `setup.py` file.
 
 Additionally, this repository contains files from the community-driven Docker image to set up Netbox, along with all its dependencies, such as a PostgreSQL database. Please note: This is not an installation for a production environment, as it uses default passwords and API keys as specified in the project's files. Furthermore, this installation sets up Netbox in 'developer mode', which means that the user will receive detailed information in case of an exception. This is very useful for alpha and beta testing, which is why this installation option is described below:
 
@@ -29,22 +29,22 @@ Therefore, for simplicity, a web browser should be available on the installed sy
 
 1. Execute the following commands:
 
-    ```text
-    cd /home/
-    apt update
-    apt install apt-transport-https ca-certificates curl software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable"
-    apt-cache policy docker-ce
-    apt install docker-ce
-    ```
+```bash
+cd /home/
+apt update
+apt install apt-transport-https ca-certificates curl software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable"
+apt-cache policy docker-ce
+apt install docker-ce
+```
 
-    ```text
-    git clone https://github.com/DINA-community/DDDC-Netbox-plugin.git
-    cd /home/d3c/
-    docker compose build --no-cache
-    docker compose up
-    ```
+```bash
+git clone https://github.com/DINA-community/DDDC-Netbox-plugin.git
+cd /home/d3c/
+docker compose build --no-cache
+docker compose up
+```
 
 2. Wait until `Initialisation is done.` is printed. Afterwards the GUI can be accessed via [http://127.0.0.1:8000](http://127.0.0.1:8000).
 3. Login as

--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ Therefore, for simplicity, a web browser should be available on the installed sy
 ```bash
 cd /home/
 apt update
-apt install apt-transport-https ca-certificates curl software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable"
+apt install apt-transport-https ca-certificates curl
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
+curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" | gpg --dearmor | tee /etc/apt/trusted.gpg.d/docker.gpg > /dev/null
 apt-cache policy docker-ce
 apt install docker-ce
 ```
 
 ```bash
 git clone https://github.com/DINA-community/DDDC-Netbox-plugin.git
-cd /home/d3c/
+cd /home/DDDC-Netbox-plugin/
 docker compose build --no-cache
 docker compose up
 ```


### PR DESCRIPTION
- use bash highlighting
- fix directory name
- remove deprecated apt-key tool
- instead of allowing the docker apt-key for all sources, only allow it for the docker source to increase the system's security
- remove the inconsistency of commands with sudo and without sudo