### PR TITLE
fix: add error message for missing manufacturer

### DIFF
--- a/d3c/forms.py
+++ b/d3c/forms.py
@@ -706,7 +706,8 @@ class SoftwareForm(NetBoxModelForm):
     manufacturer = DynamicModelChoiceField(
         queryset=Manufacturer.objects.all(),
         required=True,
-        label="Manufacturer"
+        label="Manufacturer",
+        error_messages={'required': 'Manufacturer is required.'}
     )
         
     cpe = forms.CharField(required=False, label="CPE", validators=[validate_cpe])


### PR DESCRIPTION
The form shows an empty name field and a manufacturer drop down with default value `---------`.
But that shown value not an actual value. Not changing is gives no feedback from the application what's wrong.
This adds an error message to point the user to this.